### PR TITLE
Fix Error when adding second Team to Delivery on update

### DIFF
--- a/Lighthouse.Backend/Lighthouse.Backend/Services/Implementation/Repositories/DeliveryRepository.cs
+++ b/Lighthouse.Backend/Lighthouse.Backend/Services/Implementation/Repositories/DeliveryRepository.cs
@@ -32,7 +32,7 @@ namespace Lighthouse.Backend.Services.Implementation.Repositories
         private IQueryable<Delivery> GetAllDeliveriesWithIncludes()
         {
             return Context.Deliveries
-                    .Include(d => d.Portfolio)
+                    .Include(d => d.Portfolio).ThenInclude(p => p!.Teams)
                     .Include(d => d.Features).ThenInclude(f => f.Forecasts).ThenInclude(f => f.SimulationResults)
                     .Include(d => d.Features).ThenInclude(f => f.FeatureWork).ThenInclude(fw => fw.Team);
         }


### PR DESCRIPTION
Add ThenInclude for Portfolio Teams in DeliveryRepository

Steps to reproduce:
- create delivery by one team
- try to update delivery and add a project from another team