### PR TITLE
fix(metrics): wire Work Item Age Percentiles widget chrome

### DIFF
--- a/Lighthouse.Frontend/src/pages/Common/MetricsView/BaseMetricsView.test.tsx
+++ b/Lighthouse.Frontend/src/pages/Common/MetricsView/BaseMetricsView.test.tsx
@@ -3701,6 +3701,48 @@ describe("BaseMetricsView component", () => {
 		});
 	});
 
+	describe("Work Item Age Percentiles widget chrome", () => {
+		// Regression: the workItemAgePercentiles widget shipped without any
+		// chrome wiring, so WidgetShell rendered no header bar (no info button,
+		// no view-data button). Per the docs this widget has info + view-data
+		// but intentionally no status indicator and no trend.
+		it("wires info and view-data chrome but no status badge or trend", async () => {
+			renderWithRouter(
+				<BaseMetricsView
+					entity={mockProject}
+					metricsService={mockMetricsService}
+					title="Features"
+					defaultDateRange={30}
+					doingStates={["To Do", "In Progress", "Review"]}
+				/>,
+			);
+
+			// flow-overview default category includes workItemAgePercentiles
+			await waitFor(() => {
+				expect(
+					screen.getByTestId("widget-info-workItemAgePercentiles"),
+				).toBeInTheDocument();
+				expect(
+					screen.getByTestId("widget-info-link-workItemAgePercentiles"),
+				).toHaveAttribute(
+					"href",
+					expect.stringContaining("widgets.html#work-item-age-percentiles"),
+				);
+				expect(
+					screen.getByTestId("widget-view-data-workItemAgePercentiles"),
+				).toBeInTheDocument();
+			});
+
+			// Documented behaviour: no RAG status indicator and no trend arrow
+			expect(
+				screen.queryByTestId("widget-rag-workItemAgePercentiles"),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByTestId("widget-trend-workItemAgePercentiles"),
+			).not.toBeInTheDocument();
+		});
+	});
+
 	describe("View Data Shell Wiring", () => {
 		it("passes viewData to cycle time percentiles widget", async () => {
 			renderWithRouter(

--- a/Lighthouse.Frontend/src/pages/Common/MetricsView/BaseMetricsView.tsx
+++ b/Lighthouse.Frontend/src/pages/Common/MetricsView/BaseMetricsView.tsx
@@ -525,6 +525,11 @@ function buildViewData(
 			items: inputs.inProgressItems,
 			highlightColumn: ageHighlight,
 		},
+		workItemAgePercentiles: {
+			title: `${inputs.title} in Progress`,
+			items: inputs.inProgressItems,
+			highlightColumn: ageHighlight,
+		},
 		throughput: {
 			title: `${inputs.title} Completed`,
 			items: throughputItems,

--- a/Lighthouse.Frontend/src/pages/Common/MetricsView/WidgetShell.tsx
+++ b/Lighthouse.Frontend/src/pages/Common/MetricsView/WidgetShell.tsx
@@ -33,7 +33,7 @@ type WidgetFooter = {
 type WidgetInfo = {
 	readonly description: string;
 	readonly learnMoreUrl: string;
-	readonly statusGuidance: WidgetStatusGuidance;
+	readonly statusGuidance?: WidgetStatusGuidance;
 };
 
 export type ViewDataPayload = {
@@ -287,7 +287,7 @@ const WidgetShell: React.FC<WidgetShellProps> = ({
 															color="text.secondary"
 															sx={{ lineHeight: 1.45 }}
 														>
-															{info.statusGuidance[guidanceKey]}
+															{info.statusGuidance?.[guidanceKey]}
 														</Typography>
 													</Box>
 												))}

--- a/Lighthouse.Frontend/src/pages/Common/MetricsView/widgetInfoMetadata.test.ts
+++ b/Lighthouse.Frontend/src/pages/Common/MetricsView/widgetInfoMetadata.test.ts
@@ -17,6 +17,7 @@ describe("widgetInfoMetadata", () => {
 			"predictabilityScore",
 			"predictabilityScoreDetails",
 			"percentiles",
+			"workItemAgePercentiles",
 			"totalWorkItemAge",
 			"throughput",
 			"cycleScatter",
@@ -53,9 +54,13 @@ describe("widgetInfoMetadata", () => {
 			expect(entry.description.length).toBeGreaterThan(0);
 			expect(entry.learnMoreUrl).toContain(DOCS_BASE);
 			expect(entry.learnMoreUrl).toMatch(/#.+/);
-			expect(entry.statusGuidance.sustain.length).toBeGreaterThan(0);
-			expect(entry.statusGuidance.observe.length).toBeGreaterThan(0);
-			expect(entry.statusGuidance.act.length).toBeGreaterThan(0);
+			// statusGuidance is optional: widgets without a RAG status indicator
+			// (e.g. Work Item Age Percentiles) omit it. When present it must be complete.
+			if (entry.statusGuidance) {
+				expect(entry.statusGuidance.sustain.length).toBeGreaterThan(0);
+				expect(entry.statusGuidance.observe.length).toBeGreaterThan(0);
+				expect(entry.statusGuidance.act.length).toBeGreaterThan(0);
+			}
 		}
 	});
 
@@ -75,13 +80,13 @@ describe("widgetInfoMetadata", () => {
 		expect(info).toBeDefined();
 		expect(info?.description.length).toBeGreaterThan(0);
 		expect(info?.learnMoreUrl).toBe(`${DOCS_BASE}#cumulative-time-per-state`);
-		expect(info?.statusGuidance.sustain).toBe(
+		expect(info?.statusGuidance?.sustain).toBe(
 			"No single state holds 40% or more of the total time.",
 		);
-		expect(info?.statusGuidance.observe).toBe(
+		expect(info?.statusGuidance?.observe).toBe(
 			"One state holds between 40% and 60% of the total time.",
 		);
-		expect(info?.statusGuidance.act).toBe(
+		expect(info?.statusGuidance?.act).toBe(
 			"One state holds more than 60% of the total time, or no time is in scope. Investigate the bottleneck or widen the filter.",
 		);
 	});

--- a/Lighthouse.Frontend/src/pages/Common/MetricsView/widgetInfoMetadata.ts
+++ b/Lighthouse.Frontend/src/pages/Common/MetricsView/widgetInfoMetadata.ts
@@ -103,7 +103,7 @@ export const widgetInfoMetadata: Record<string, WidgetInfoEntry> = {
 	},
 	workItemAgePercentiles: {
 		description:
-			"Work Item Age percentiles (50th, 70th, 85th, and 95th) for the items currently in progress — a live snapshot of how long your in-progress work has been ageing right now. Unlike Cycle Time Percentiles, which summarizes completed work, this has no status indicator.",
+			"The 50th, 70th, 85th, and 95th percentiles of Work Item Age for the items that are currently in progress — a live snapshot of how long your in-progress work has been ageing right now.",
 		learnMoreUrl: `${DOCS_BASE}#work-item-age-percentiles`,
 	},
 	totalWorkItemAge: {

--- a/Lighthouse.Frontend/src/pages/Common/MetricsView/widgetInfoMetadata.ts
+++ b/Lighthouse.Frontend/src/pages/Common/MetricsView/widgetInfoMetadata.ts
@@ -9,7 +9,9 @@ export interface WidgetStatusGuidance {
 export interface WidgetInfoEntry {
 	readonly description: string;
 	readonly learnMoreUrl: string;
-	readonly statusGuidance: WidgetStatusGuidance;
+	// Optional: widgets without a RAG status indicator (e.g. snapshot metrics)
+	// provide no status guidance and render only the description + Learn More.
+	readonly statusGuidance?: WidgetStatusGuidance;
 }
 
 export const widgetInfoMetadata: Record<string, WidgetInfoEntry> = {
@@ -98,6 +100,11 @@ export const widgetInfoMetadata: Record<string, WidgetInfoEntry> = {
 				"The percentage of items within SLE is below target by up to 20 percentage points.",
 			act: "No SLE is configured, no closed items exist in range, or within-SLE performance is more than 20 percentage points below target.",
 		},
+	},
+	workItemAgePercentiles: {
+		description:
+			"Work Item Age percentiles (50th, 70th, 85th, and 95th) for the items currently in progress — a live snapshot of how long your in-progress work has been ageing right now. Unlike Cycle Time Percentiles, which summarizes completed work, this has no status indicator.",
+		learnMoreUrl: `${DOCS_BASE}#work-item-age-percentiles`,
 	},
 	totalWorkItemAge: {
 		description:


### PR DESCRIPTION
## Problem

On a team's **Metrics → Flow Overview** tab, the **Work Item Age Percentiles** card renders without its top action bar — no info (ⓘ) button and no "view data" button — while its sibling **Cycle Time Percentiles** card shows them. Reproduces for all teams.

## Root cause

The widget was registered as a render node (`buildWidgetNodes`) and placed in the `flow-overview` category (`categoryMetadata.ts`), but was never added to the chrome registries that feed `WidgetShell`'s header — `widgetInfoMetadata` and `buildViewData`. With `info`, `viewData`, `trend` and `footer` all `undefined`, `WidgetShell`'s `hasHeader` evaluated to `false` and the entire header `Box` was skipped:

```ts
// WidgetShell.tsx
const hasHeader =
    !!title || (header && showTips) || !!info || hasViewData || hasTrend;
```

Because the registries are `Record<string, …>`, the missing key was silently `undefined` rather than a compile error — a classic clone-and-forget when the card was cloned from Cycle Time Percentiles.

## Fix

Per the [docs](https://docs.lighthouse.letpeople.work/metrics/widgets.html#work-item-age-percentiles), this widget is a *live snapshot* of in-progress Work Item Age and intentionally has **no status indicator and no trend**. So this restores only the documented chrome:

- **`widgetInfoMetadata`** — adds the `workItemAgePercentiles` entry (description + "Learn More" → `#work-item-age-percentiles`), restoring the ⓘ button.
- **`buildViewData`** — adds the `workItemAgePercentiles` entry (reusing in-progress items, mirroring the Total Work Item Age card), restoring the "view data" button.
- **`statusGuidance` made optional** — so a widget with no RAG status renders just the description + Learn More, with no status guidance chips.

No RAG badge and no trend arrow are wired (matches the docs).

## Tests

- New regression test in `BaseMetricsView.test.tsx`: asserts the info + view-data chrome is wired for `workItemAgePercentiles` and that **no** RAG badge / trend is rendered. Fails before the fix, passes after.
- Extended `widgetInfoMetadata.test.ts` coverage list to require an entry for `workItemAgePercentiles`, and relaxed the per-entry assertion to treat `statusGuidance` as optional — guarding against this exact gap recurring.

## Verification

- `tsc -b` — clean
- `vite build` — clean
- `vitest run` over the Metrics views — all pass (one unrelated pre-existing flaky `DashboardHeader` test fails only under full-suite parallel load; passes in isolation with and without this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)