### PR TITLE
fix(metrics): restore x-axis tick labels on estimation and feature size scatter charts

### DIFF
--- a/Lighthouse.Frontend/src/components/Common/Charts/EstimationVsCycleTimeChart.test.tsx
+++ b/Lighthouse.Frontend/src/components/Common/Charts/EstimationVsCycleTimeChart.test.tsx
@@ -1,3 +1,4 @@
+import * as MuiCharts from "@mui/x-charts";
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
@@ -175,6 +176,53 @@ describe("EstimationVsCycleTimeChart component", () => {
 
 		expect(screen.getByText("Estimation vs. Cycle Time")).toBeInTheDocument();
 		expect(screen.getByTestId("mock-chart-container")).toBeInTheDocument();
+	});
+
+	// Regression: the x-axis tick labels (e.g. Story Point numbers) disappeared
+	// because ChartsXAxis/ChartsYAxis were rendered without an explicit axisId
+	// while the axes are registered under custom ids ("estimationAxis" /
+	// "cycleTimeAxis"). Mirrors the fix pattern from CycleTimeScatterPlotChart.
+	it("uses explicit axis IDs and x-axis height for stable tick rendering", () => {
+		render(
+			<EstimationVsCycleTimeChart
+				data={makeResponse()}
+				workItemLookup={mockWorkItemLookup}
+			/>,
+		);
+
+		const chartsContainerMock = MuiCharts.ChartsContainer as unknown as {
+			mock: { calls: Array<[Record<string, unknown>]> };
+		};
+		const xAxisMock = MuiCharts.ChartsXAxis as unknown as {
+			mock: { calls: Array<[Record<string, unknown>]> };
+		};
+		const yAxisMock = MuiCharts.ChartsYAxis as unknown as {
+			mock: { calls: Array<[Record<string, unknown>]> };
+		};
+
+		const containerProps =
+			chartsContainerMock.mock.calls[
+				chartsContainerMock.mock.calls.length - 1
+			]?.[0];
+		expect(containerProps).toBeTruthy();
+
+		const xAxisConfig = (
+			containerProps?.xAxis as Array<Record<string, unknown>>
+		)?.[0];
+		expect(xAxisConfig?.id).toBe("estimationAxis");
+		expect(xAxisConfig?.height).toBe(56);
+
+		expect(
+			xAxisMock.mock.calls.some(
+				([props]) => (props as { axisId?: string })?.axisId === "estimationAxis",
+			),
+		).toBe(true);
+
+		expect(
+			yAxisMock.mock.calls.some(
+				([props]) => (props as { axisId?: string })?.axisId === "cycleTimeAxis",
+			),
+		).toBe(true);
 	});
 
 	it("should include estimation unit in x-axis label when provided", () => {

--- a/Lighthouse.Frontend/src/components/Common/Charts/EstimationVsCycleTimeChart.tsx
+++ b/Lighthouse.Frontend/src/components/Common/Charts/EstimationVsCycleTimeChart.tsx
@@ -118,6 +118,7 @@ const EstimationVsCycleTimeChart: React.FC<EstimationVsCycleTimeChartProps> = ({
 			id: "estimationAxis",
 			scaleType: "linear" as const,
 			label: xAxisLabel,
+			height: 56,
 		};
 
 		if (data.useNonNumericEstimation && data.categoryValues.length > 0) {
@@ -237,8 +238,8 @@ const EstimationVsCycleTimeChart: React.FC<EstimationVsCycleTimeChartProps> = ({
 							},
 						]}
 					>
-						<ChartsXAxis />
-						<ChartsYAxis />
+						<ChartsXAxis axisId="estimationAxis" />
+						<ChartsYAxis axisId="cycleTimeAxis" />
 						<ScatterPlot
 							slots={{
 								marker: (props) =>

--- a/Lighthouse.Frontend/src/components/Common/Charts/FeatureSizeScatterPlotChart.test.tsx
+++ b/Lighthouse.Frontend/src/components/Common/Charts/FeatureSizeScatterPlotChart.test.tsx
@@ -1,3 +1,4 @@
+import * as MuiCharts from "@mui/x-charts";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Feature, type IFeature } from "../../../models/Feature";
@@ -41,6 +42,8 @@ vi.mock("@mui/x-charts", () => {
 		children: React.ReactNode;
 		height: number;
 		xAxis?: Array<{
+			id?: string;
+			height?: number;
 			max?: number;
 			label?: string;
 			valueFormatter?: (v: number) => string;
@@ -77,6 +80,8 @@ vi.mock("@mui/x-charts", () => {
 				<div
 					data-testid="chart-container"
 					data-height={height}
+					data-x-axis-id={xAxis?.[0]?.id}
+					data-x-axis-height={xAxis?.[0]?.height}
 					data-x-axis-max={xAxis?.[0]?.max}
 					data-x-axis-label={xAxis?.[0]?.label}
 					data-y-axis-label={yAxis?.[0]?.label}
@@ -199,8 +204,8 @@ vi.mock("@mui/x-charts", () => {
 				</div>
 			);
 		},
-		ChartsXAxis: () => <div data-testid="x-axis">X Axis</div>,
-		ChartsYAxis: () => <div data-testid="y-axis">Y Axis</div>,
+		ChartsXAxis: vi.fn(() => <div data-testid="x-axis">X Axis</div>),
+		ChartsYAxis: vi.fn(() => <div data-testid="y-axis">Y Axis</div>),
 		ChartsTooltip: () => <div data-testid="tooltip">Tooltip</div>,
 		ChartsReferenceLine: ({
 			label,
@@ -305,6 +310,37 @@ describe("FeatureSizeScatterPlotChart", () => {
 			expect(screen.getByTestId("x-axis")).toBeInTheDocument();
 			expect(screen.getByTestId("y-axis")).toBeInTheDocument();
 			expect(screen.getByTestId("tooltip")).toBeInTheDocument();
+		});
+
+		// Regression: the x-axis tick labels disappeared because
+		// ChartsXAxis/ChartsYAxis were rendered without an explicit axisId while
+		// the axes are registered under custom ids ("sizeAxis" / "timeAxis").
+		// Mirrors the fix pattern from CycleTimeScatterPlotChart.
+		it("uses explicit axis IDs and x-axis height for stable tick rendering", () => {
+			render(<FeatureSizeScatterPlotChart sizeDataPoints={basicFeatures} />);
+
+			const container = screen.getByTestId("chart-container");
+			expect(container.dataset.xAxisId).toBe("sizeAxis");
+			expect(container.dataset.xAxisHeight).toBe("56");
+
+			const xAxisMock = MuiCharts.ChartsXAxis as unknown as {
+				mock: { calls: Array<[Record<string, unknown>]> };
+			};
+			const yAxisMock = MuiCharts.ChartsYAxis as unknown as {
+				mock: { calls: Array<[Record<string, unknown>]> };
+			};
+
+			expect(
+				xAxisMock.mock.calls.some(
+					([props]) => (props as { axisId?: string })?.axisId === "sizeAxis",
+				),
+			).toBe(true);
+
+			expect(
+				yAxisMock.mock.calls.some(
+					([props]) => (props as { axisId?: string })?.axisId === "timeAxis",
+				),
+			).toBe(true);
 		});
 
 		it("renders visible markers as SVG circles", () => {

--- a/Lighthouse.Frontend/src/components/Common/Charts/FeatureSizeScatterPlotChart.tsx
+++ b/Lighthouse.Frontend/src/components/Common/Charts/FeatureSizeScatterPlotChart.tsx
@@ -582,6 +582,7 @@ const FeatureSizeScatterPlotChart: React.FC<
 				id: "sizeAxis",
 				scaleType: "time" as const,
 				label: "Closed Date",
+				height: 56,
 				max: today,
 				valueFormatter: dateValueFormatter,
 			}
@@ -589,6 +590,7 @@ const FeatureSizeScatterPlotChart: React.FC<
 				id: "sizeAxis",
 				scaleType: "linear" as const,
 				label: `${sizeTerm} (Child Items)`,
+				height: 56,
 				min: 0,
 				max:
 					fixedXAxisMax ??
@@ -742,8 +744,8 @@ const FeatureSizeScatterPlotChart: React.FC<
 								/>
 							);
 						})}
-						<ChartsXAxis />
-						<ChartsYAxis />
+						<ChartsXAxis axisId="sizeAxis" />
+						<ChartsYAxis axisId="timeAxis" />
 						<ScatterPlot
 							slots={{
 								marker: (props) =>


### PR DESCRIPTION
## Problem

On the **Estimation vs. Cycle Time** chart, the x-axis no longer shows the estimation values (e.g. Story Point numbers) — the axis renders without tick labels. The **Feature Size** scatter chart has the identical latent defect on its x-axis.

## Root cause

Both charts register their axes under custom ids but render the axis components without an `axisId`:

```tsx
// EstimationVsCycleTimeChart.tsx — axes registered as "estimationAxis" / "cycleTimeAxis"
<ChartsXAxis />
<ChartsYAxis />

// FeatureSizeScatterPlotChart.tsx — axes registered as "sizeAxis" / "timeAxis"
<ChartsXAxis />
<ChartsYAxis />
```

Since the mui-x charts v9 setup, `ChartsXAxis`/`ChartsYAxis` must reference the registered axis id or the ticks don't render. Commit 88291613 (*"enhance chart components with explicit axis IDs and increased x-axis height for stable tick rendering"*) fixed exactly this for `CycleTimeScatterPlotChart`, `StackedAreaChart`, and `WorkItemAgingChart` — but missed these two charts.

## Fix

Mirrors the established pattern from 88291613 in both charts:

- pass `axisId` to `ChartsXAxis` / `ChartsYAxis`, matching the registered axis ids
- add `height: 56` to the x-axis config for stable tick rendering

## Tests

Regression tests added to both chart test files — *"uses explicit axis IDs and x-axis height for stable tick rendering"*, mirroring the existing `CycleTimeScatterPlotChart` test. Both fail before the fix and pass after. The FeatureSize test mock was extended (`vi.fn` axis mocks + axis id/height data attributes) to make the assertion possible.

## Verification

- `tsc -b` — clean
- `vite build` — clean
- Charts test suite: 514/515 pass — the 1 failure (`CumulativeStateTimeItemPicker`) is a pre-existing flaky test that passes in isolation both with and without this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)