### PR TITLE
fix(licensing): accept licenses with non-ASCII names (Bug 5382)

### DIFF
--- a/Lighthouse.Backend/Lighthouse.Backend.Tests/Services/Implementation/Licensing/LicenseVerifierTest.cs
+++ b/Lighthouse.Backend/Lighthouse.Backend.Tests/Services/Implementation/Licensing/LicenseVerifierTest.cs
@@ -1,4 +1,4 @@
-﻿using Lighthouse.Backend.Models;
+using Lighthouse.Backend.Models;
 using Lighthouse.Backend.Services.Implementation.Licensing;
 
 namespace Lighthouse.Backend.Tests.Services.Implementation.Licensing
@@ -6,24 +6,30 @@ namespace Lighthouse.Backend.Tests.Services.Implementation.Licensing
     [TestFixture]
     public class LicenseVerifierTest
     {
+        // Accented characters in this fixture are built from explicit code points
+        // ((char)0x00E9 = precomposed 'e-acute', (char)0x0301 = combining acute) so the
+        // source file stays pure ASCII and is immune to editor/Unicode-normalization drift.
+        private const char EAcute = (char)0x00E9;      // precomposed (NFC)
+        private const char CombiningAcute = (char)0x0301; // combining accent (NFD when after 'e')
+
         [Test]
         public void VerifyLicense_ValidLicenseWithoutValidFrom_ReturnsTrue()
         {
             var verifier = new LicenseVerifier();
-            
+
             // Extract license from file
             using var doc = System.Text.Json.JsonDocument.Parse(TestLicenseData.ValidExpiredLicense);
             var licenseElement = doc.RootElement.GetProperty("license");
             var signature = doc.RootElement.GetProperty("signature").GetString();
-            
+
             var license = new LicenseInformation
             {
                 Name = licenseElement.GetProperty("name").GetString() ?? string.Empty,
                 Email = licenseElement.GetProperty("email").GetString() ?? string.Empty,
                 Organization = licenseElement.GetProperty("organization").GetString() ?? string.Empty,
                 ExpiryDate = DateTime.SpecifyKind(licenseElement.GetProperty("expiry").GetDateTime(), DateTimeKind.Utc),
-                LicenseNumber = licenseElement.TryGetProperty("license_number", out var licenseNumberElement) 
-                    ? licenseNumberElement.GetString() ?? string.Empty 
+                LicenseNumber = licenseElement.TryGetProperty("license_number", out var licenseNumberElement)
+                    ? licenseNumberElement.GetString() ?? string.Empty
                     : string.Empty,
                 ValidFrom = null,
                 Signature = signature ?? string.Empty,
@@ -38,7 +44,7 @@ namespace Lighthouse.Backend.Tests.Services.Implementation.Licensing
         public void VerifyLicense_LicenseWithValidFrom_VerifiesCorrectly()
         {
             var verifier = new LicenseVerifier();
-            
+
             // Create a license with ValidFrom - this won't verify against a real signature
             // but tests the canonicalization logic
             var license = new LicenseInformation
@@ -62,7 +68,7 @@ namespace Lighthouse.Backend.Tests.Services.Implementation.Licensing
         public void VerifyLicense_EmptySignature_ReturnsFalse()
         {
             var verifier = new LicenseVerifier();
-            
+
             var license = new LicenseInformation
             {
                 Name = "Test User",
@@ -83,7 +89,7 @@ namespace Lighthouse.Backend.Tests.Services.Implementation.Licensing
         public void VerifyLicense_NullSignature_ReturnsFalse()
         {
             var verifier = new LicenseVerifier();
-            
+
             var license = new LicenseInformation
             {
                 Name = "Test User",
@@ -104,7 +110,7 @@ namespace Lighthouse.Backend.Tests.Services.Implementation.Licensing
         public void VerifyLicense_InvalidSignatureFormat_ReturnsFalse()
         {
             var verifier = new LicenseVerifier();
-            
+
             var license = new LicenseInformation
             {
                 Name = "Test User",
@@ -119,6 +125,82 @@ namespace Lighthouse.Backend.Tests.Services.Implementation.Licensing
             var result = verifier.VerifyLicense(license);
 
             Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void CanonicalizeJson_NameWithAccentedCharacter_MatchesRawUtf8SignerBytes()
+        {
+            // Regression test for Bug 5382: licenses with accented names failed to import.
+            // The Python signer emits the name as raw UTF-8, but C#'s default JSON encoder
+            // emitted an uppercase e-acute escape. The differing byte sequences produced
+            // different SHA-256 hashes, so RSA verification rejected the license. The canonical
+            // output must be byte-identical to the signer's raw-UTF-8 form.
+            var name = "Jan" + EAcute + "e McConnell"; // precomposed NFC
+            var license = new LicenseInformation
+            {
+                LicenseNumber = "65",
+                Name = name,
+                Email = "janee.mcconnell@epsilon.com",
+                Organization = "Epsilon (part of Publicis Groupe)",
+                ExpiryDate = DateTime.SpecifyKind(new DateTime(2026, 7, 31), DateTimeKind.Utc),
+                ValidFrom = DateTime.SpecifyKind(new DateTime(2026, 6, 28), DateTimeKind.Utc),
+                Signature = string.Empty,
+            };
+
+            var canonical = LicenseVerifier.CanonicalizeJson(license);
+
+            var expected =
+                "{\"email\":\"janee.mcconnell@epsilon.com\",\"expiry\":\"2026-07-31\"," +
+                "\"license_number\":\"65\",\"name\":\"" + name + "\"," +
+                "\"organization\":\"Epsilon (part of Publicis Groupe)\",\"valid_from\":\"2026-06-28\"}";
+            Assert.That(canonical, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void CanonicalizeJson_OrganizationWithAmpersand_EmitsRawAmpersandNotEscaped()
+        {
+            // Latent second facet of Bug 5382: C#'s default encoder also escapes HTML-sensitive
+            // ASCII (& < > + '), which the Python signer leaves literal. Names/orgs such as
+            // "Johnson & Johnson" would fail verification for the same reason accents did.
+            var license = new LicenseInformation
+            {
+                LicenseNumber = "70",
+                Name = "Test User",
+                Email = "test@example.com",
+                Organization = "Johnson & Johnson",
+                ExpiryDate = DateTime.SpecifyKind(new DateTime(2026, 12, 31), DateTimeKind.Utc),
+                ValidFrom = null,
+                Signature = string.Empty,
+            };
+
+            var canonical = LicenseVerifier.CanonicalizeJson(license);
+
+            Assert.That(canonical, Does.Contain("Johnson & Johnson"));
+            Assert.That(canonical, Does.Not.Contain("\\u0026"));
+        }
+
+        [Test]
+        public void CanonicalizeJson_DecomposedAccent_NormalizedToComposedForm()
+        {
+            // Hardening for Bug 5382: a name supplied in NFD (decomposed) form - 'e' followed by
+            // a combining acute accent - must canonicalize to the same NFC (precomposed) bytes
+            // the signer produces, so equivalent Unicode representations verify identically.
+            var decomposedName = "Jane" + CombiningAcute + "e McConnell"; // NFD
+            var expectedComposed = "Jan" + EAcute + "e McConnell";        // NFC
+            var license = new LicenseInformation
+            {
+                LicenseNumber = "71",
+                Name = decomposedName,
+                Email = "test@example.com",
+                Organization = "Test Org",
+                ExpiryDate = DateTime.SpecifyKind(new DateTime(2026, 12, 31), DateTimeKind.Utc),
+                ValidFrom = null,
+                Signature = string.Empty,
+            };
+
+            var canonical = LicenseVerifier.CanonicalizeJson(license);
+
+            Assert.That(canonical, Does.Contain(expectedComposed));
         }
     }
 }

--- a/Lighthouse.Backend/Lighthouse.Backend/Services/Implementation/Licensing/LicenseVerifier.cs
+++ b/Lighthouse.Backend/Lighthouse.Backend/Services/Implementation/Licensing/LicenseVerifier.cs
@@ -1,8 +1,9 @@
-﻿using Lighthouse.Backend.Models;
+using Lighthouse.Backend.Models;
 using Lighthouse.Backend.Services.Interfaces.Licensing;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 
 namespace Lighthouse.Backend.Services.Implementation.Licensing
@@ -44,7 +45,7 @@ namespace Lighthouse.Backend.Services.Implementation.Licensing
             }
         }
 
-        private static string CanonicalizeJson(LicenseInformation license)
+        internal static string CanonicalizeJson(LicenseInformation license)
         {
             var dict = new SortedDictionary<string, object>
             {
@@ -61,7 +62,16 @@ namespace Lighthouse.Backend.Services.Implementation.Licensing
             }
 
             using var stream = new MemoryStream();
-            using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = false });
+
+            // Emit raw UTF-8 with only the JSON-mandatory escapes so the canonical bytes are
+            // byte-identical to the signer (Python json.dumps with ensure_ascii=False). The
+            // default encoder escapes non-ASCII (e.g. "e-acute") and HTML-sensitive ASCII
+            // ("&"), diverging from the signed bytes and rejecting valid licenses (Bug 5382).
+            using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
+            {
+                Indented = false,
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            });
 
             writer.WriteStartObject();
             foreach (var kvp in dict)
@@ -71,7 +81,9 @@ namespace Lighthouse.Backend.Services.Implementation.Licensing
                 switch (kvp.Value)
                 {
                     case string stringValue:
-                        writer.WriteStringValue(stringValue);
+                        // Normalize to NFC so decomposed and precomposed spellings of the same
+                        // character (e.g. "e" + combining acute vs "e-acute") produce identical bytes.
+                        writer.WriteStringValue(stringValue.Normalize(NormalizationForm.FormC));
                         break;
                     case DateTime dateValue:
                         writer.WriteStringValue(dateValue.ToString("yyyy-MM-dd"));

--- a/Scripts/generate_license.py
+++ b/Scripts/generate_license.py
@@ -1,6 +1,7 @@
 import sys
 import json
 import base64
+import unicodedata
 from datetime import datetime
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
@@ -40,16 +41,25 @@ def main():
         print("Valid from date must be in YYYY-MM-DD format")
         sys.exit(1)
 
+    # Normalize text fields to Unicode NFC so the signed bytes match what the
+    # backend verifier produces (it also normalizes to NFC). Without this,
+    # decomposed vs precomposed spellings of accented characters would diverge.
+    def nfc(value):
+        return unicodedata.normalize("NFC", value)
+
     license_data = {
         "license_number": str(license_number),  # ensure string for JSON stability
-        "name": name,
-        "email": email,
-        "organization": organization,
+        "name": nfc(name),
+        "email": nfc(email),
+        "organization": nfc(organization),
         "expiry": expiry,
         "valid_from": valid_from,
     }
 
-    license_json = json.dumps(license_data, separators=(',', ':'), sort_keys=True).encode("utf-8")
+    # ensure_ascii=False emits raw UTF-8 (e.g. accented characters as themselves)
+    # rather than \uXXXX escapes, matching the backend's canonical byte form.
+    # See Bug 5382 - lowercase Python escapes never matched C#'s uppercase escapes.
+    license_json = json.dumps(license_data, separators=(',', ':'), sort_keys=True, ensure_ascii=False).encode("utf-8")
 
     with open(private_key_path, "rb") as f:
         private_key = serialization.load_pem_private_key(

--- a/Scripts/verify_license.py
+++ b/Scripts/verify_license.py
@@ -1,6 +1,7 @@
 import sys
 import json
 import base64
+import unicodedata
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.backends import default_backend
@@ -27,7 +28,13 @@ def main():
         print("Invalid license file format")
         sys.exit(1)
 
-    license_json = json.dumps(license_data, separators=(',', ':'), sort_keys=True).encode("utf-8")
+    # Match the signer/backend canonicalization: NFC-normalize text fields and emit
+    # raw UTF-8 (ensure_ascii=False) so the verified bytes are byte-identical. See Bug 5382.
+    license_data = {
+        key: unicodedata.normalize("NFC", value) if isinstance(value, str) else value
+        for key, value in license_data.items()
+    }
+    license_json = json.dumps(license_data, separators=(',', ':'), sort_keys=True, ensure_ascii=False).encode("utf-8")
     signature = base64.b64decode(signature_b64)
 
     try:


### PR DESCRIPTION
License import rejected any license whose signed payload contained a non-ASCII character (e.g. "é" in "Janée McConnell") while the plain-ASCII equivalent imported fine.

Root cause: signer and verifier re-serialize the payload independently with incompatible JSON escaping. Python json.dumps used ensure_ascii=True (lowercase é); C# Utf8JsonWriter used the default encoder (uppercase é, and it also escapes & < > + '). System.Text.Json cannot emit lowercase escapes, so non-ASCII bytes never matched -> RSA verification failed. ASCII names produce no escapes, so they always matched.

Fix: align both sides on raw UTF-8 with minimal escaping (proven byte-identical, same SHA-256):
- LicenseVerifier: JavaScriptEncoder.UnsafeRelaxedJsonEscaping
- generate_license.py / verify_license.py: ensure_ascii=False
- NFC-normalize text fields on both sides so decomposed vs precomposed spellings converge (hardening).

This also fixes a latent failure for names/orgs containing & < > + '.

Note: already-issued licenses with non-ASCII (or & < > + ') characters must be re-issued with the updated signer; pure-ASCII licenses are unaffected.

Regression tests pin the C# canonical output to the signer's raw-UTF-8 bytes, cover the ampersand case, and assert NFC convergence.