### PR TITLE
Docs: state category facts in the landing intro

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 nav_order: 1
 ---
 
-Lighthouse is a tool that helps you run probabilistic forecasts using Monte Carlo Simulations in a continuous and simple way. It connects to your Work Tracking Tool (currently Jira, Azure DevOps, and CSV are supported) and will automatically update your team's Throughput and your portfolio's forecasted delivery dates.
+Lighthouse is an open-source, self-hosted flow metrics and Monte Carlo forecasting tool for software delivery teams. It helps you run probabilistic forecasts in a continuous and simple way: it connects to your Work Tracking Tool (currently Jira, Azure DevOps, Linear, and CSV are supported) and will automatically update your team's flow metrics and Throughput as well as your portfolio's forecasted delivery dates. Everything runs on your own infrastructure, so your data never leaves your network.
 
 <div style="text-align: center;">
     <img src="./assets/features/teamdetail.png" alt="Team Forecasts" style="max-width: 500px;">


### PR DESCRIPTION
## What

Reworks the first paragraph of the docs landing page (docs/index.md) to state the category facts plainly:

- "open-source, self-hosted flow metrics and Monte Carlo forecasting tool" (the landing previously never contained the terms "open-source", "self-hosted", or "flow metrics")
- adds **Linear** to the listed work tracking tools (the website and llms.txt already list it; the docs still said only Jira, Azure DevOps, and CSV — please double-check this is accurate for the current release)
- adds one sentence that data stays on your own infrastructure

## Why

docs.lighthouse.letpeople.work is statically crawlable and heavily scraped by search engines and AI crawlers, but the landing page never used the exact category terms people (and LLMs) search for. This is part of the broader effort to make Lighthouse discoverable by LLMs (see the new letpeople.work/compare/ page and llms.txt).

No structural changes, one paragraph only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)