### PR TITLE
fix(workitems): keep one row per ReferenceId when a fetch returns copies

### DIFF
--- a/Lighthouse.Backend/Lighthouse.Backend.Tests/Services/Implementation/WorkItems/WorkItemServiceTest.cs
+++ b/Lighthouse.Backend/Lighthouse.Backend.Tests/Services/Implementation/WorkItems/WorkItemServiceTest.cs
@@ -965,6 +965,43 @@ namespace Lighthouse.Backend.Tests.Services.Implementation.WorkItems
         }
 
         [Test]
+        public async Task UpdateWorkItemsForTeam_ConnectorReturnsSameItemTwice_PersistsItemOnceWithoutDuplicatingTransitions()
+        {
+            var team = CreateTeam();
+            var duplicates = CreateSameItemReturnedTwice(team, "Doing", new DateTime(2026, 7, 20, 8, 0, 0, DateTimeKind.Utc));
+            AssignIdentitiesOnSave();
+
+            workTrackingConnectorMock.Setup(x => x.GetWorkItemsForTeam(team)).ReturnsAsync(duplicates);
+
+            var subject = CreateSubject();
+            await subject.UpdateWorkItemsForTeam(team);
+
+            var persisted = workItems.Where(wi => wi.ReferenceId == duplicates[0].ReferenceId).ToList();
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(persisted, Has.Count.EqualTo(1));
+                Assert.That(storedTransitions, Has.Count.EqualTo(1));
+            }
+        }
+
+        [Test]
+        public async Task UpdateWorkItemsForTeam_ConnectorReturnsSameItemTwice_FollowUpSyncStillPersistsItemOnce()
+        {
+            var team = CreateTeam();
+            var duplicates = CreateSameItemReturnedTwice(team, "Doing", new DateTime(2026, 7, 20, 8, 0, 0, DateTimeKind.Utc));
+            AssignIdentitiesOnSave();
+
+            workTrackingConnectorMock.Setup(x => x.GetWorkItemsForTeam(team)).ReturnsAsync(duplicates);
+
+            var subject = CreateSubject();
+            await subject.UpdateWorkItemsForTeam(team);
+            await subject.UpdateWorkItemsForTeam(team);
+
+            var persisted = workItems.Where(wi => wi.ReferenceId == duplicates[0].ReferenceId).ToList();
+            Assert.That(persisted, Has.Count.EqualTo(1));
+        }
+
+        [Test]
         public async Task RefreshWorkItems_DerivesCurrentStateEnteredAt_FromLatestMatchingTransition_Idempotently()
         {
             var team = CreateTeam();
@@ -1234,6 +1271,32 @@ namespace Lighthouse.Backend.Tests.Services.Implementation.WorkItems
                 TeamId = existing.TeamId,
                 SyncedTransitions = syncedTransitions,
             };
+        }
+
+        private List<WorkItem> CreateSameItemReturnedTwice(Team team, string state, DateTime enteredState)
+        {
+            var template = CreateWorkItemWithTransitions(team, state, ("To Do", state, enteredState));
+
+            return
+            [
+                CreateIncomingFor(template, state, template.StateCategory, ("To Do", state, enteredState)),
+                CreateIncomingFor(template, state, template.StateCategory, ("To Do", state, enteredState)),
+            ];
+        }
+
+        // The database assigns identities on Save; without that, two rows for the same ReferenceId would
+        // both keep Id 0 and their duplicated transitions would collapse instead of being observable.
+        private void AssignIdentitiesOnSave()
+        {
+            workItemRepositoryMock.Setup(x => x.Save())
+                .Callback(() =>
+                {
+                    foreach (var unpersisted in workItems.Where(wi => wi.Id == 0).ToList())
+                    {
+                        unpersisted.Id = idCounter++;
+                    }
+                })
+                .Returns(Task.CompletedTask);
         }
 
         private void SetupWorkForFeature(Feature feature, int doneItems, int toDoItems)

--- a/Lighthouse.Backend/Lighthouse.Backend/Services/Implementation/WorkItems/WorkItemService.cs
+++ b/Lighthouse.Backend/Lighthouse.Backend/Services/Implementation/WorkItems/WorkItemService.cs
@@ -65,7 +65,7 @@ namespace Lighthouse.Backend.Services.Implementation.WorkItems
             var workItemService = workTrackingConnectorFactory.GetWorkTrackingConnector(team.WorkTrackingSystemConnection.WorkTrackingSystem);
 
             var storedWorkItems = workItemRepository.GetAllByPredicate(wi => wi.TeamId == team.Id).ToList();
-            var actualWorkItems = await workItemService.GetWorkItemsForTeam(team);
+            var actualWorkItems = DeduplicateByReferenceId(await workItemService.GetWorkItemsForTeam(team), team);
 
             var itemsWithTransitions = new List<SyncedItem>();
 
@@ -100,6 +100,25 @@ namespace Lighthouse.Backend.Services.Implementation.WorkItems
             await workItemRepository.Save();
 
             await PublishDomainEvents(events);
+        }
+
+        // Jira DC offset pagination over an unordered JQL can return the same ReferenceId twice in one fetch;
+        // persisting both breaks the SingleOrDefault above on every later sync (docs/ci-learnings.md 2026-05-25).
+        private List<WorkItem> DeduplicateByReferenceId(IEnumerable<WorkItem> fetchedWorkItems, Team team)
+        {
+            var groupedByReferenceId = fetchedWorkItems.GroupBy(workItem => workItem.ReferenceId).ToList();
+            var duplicatedGroups = groupedByReferenceId.Where(group => group.Count() > 1).ToList();
+
+            if (duplicatedGroups.Count > 0)
+            {
+                logger.LogWarning(
+                    "Work Tracking System returned {DroppedCopies} duplicate Work Item copies for Team {TeamName} - keeping the first copy of each. Affected Reference Ids: {ReferenceIds}",
+                    duplicatedGroups.Sum(group => group.Count() - 1),
+                    team.Name,
+                    string.Join(",", duplicatedGroups.Select(group => group.Key)));
+            }
+
+            return groupedByReferenceId.Select(group => group.First()).ToList();
         }
 
         private bool WasBlocked(Team team, WorkItem? existingItem)


### PR DESCRIPTION
## Problem

`TeamUpdater` aborted every sync for one team:

```
ERROR - TeamUpdater: An exception occurred while updating Team with ID 2:
        Sequence contains more than one matching element
  at WorkItemService.RefreshWorkItems(Team team) ... WorkItemService.cs:line 74
```

The team had two `WorkItems` rows sharing a `ReferenceId` — and the sync loop creates them itself.

## Root cause

In `RefreshWorkItems`, `existingItem` is resolved only against `storedWorkItems`, the snapshot taken *before* the loop (`:67`). `SyncWorkItem`'s `Add` path never updates that snapshot. So when a connector returns the same `ReferenceId` twice in one fetch, both iterations see `existingItem == null` and **both rows are inserted**.

That run succeeds silently. Both copies also enter `itemsWithTransitions`, so the second pass (`:93-97`) writes the same synced transitions onto *each* row. Every later run then reads a snapshot holding both rows, and `SingleOrDefault` (`:74`) throws before the leftover-deletion loop can be reached — the team stays broken until the rows are removed.

This is why the reported behaviour was "loads fine initially, then fails; deleted and re-added the team, and it happened again later": a fresh team has zero rows, so the first sync can only poison, never throw.

## Evidence

Jira Data Center team, 1480 items. `FIN-4732` persisted as rows 2781 and 3017 — identical apart from `Id`, with **three state transitions on each**. That symmetry is the fingerprint of a single run creating both; two separate runs would have drifted apart.

Upstream trigger is offset pagination (`startAt`/`maxResults`, `JiraWorkTrackingConnector.cs:1133-1166`) over a JQL query that carries no `ORDER BY` (`PrepareQuery`, `:1235-1242`) — an item shifting into the window between page fetches is returned twice. Teams whose result set fits in a single page never paginate, which is why only this one team failed.

## Fix

`RefreshWorkItems` is the only caller of `GetWorkItemsForTeam` in the backend, so deduplicating at the fetch covers Jira, ADO, Linear, CSV and ServiceNow without touching a connector. `GroupBy` materialises the possibly-lazy sequence once, and `First()` keeps the copy the connector returned first — so ordering is unchanged when there are no duplicates. Dropped copies are logged rather than swallowed, keeping the connector-side behaviour visible.

## Scope — deliberately preventive only

`SingleOrDefault` at `:74` is **unchanged**. Databases that already hold duplicates continue to throw, and recreating the team remains the escape hatch. Explicitly out of scope, by decision:

- cleaning up existing duplicate rows (self-healing)
- a unique index on `(TeamId, ReferenceId)` — the real structural guard, but it needs a data-cleanup migration across all three providers
- adding a stable `ORDER BY` to the JQL — fixes the trigger at source but touches every Jira query

## Tests

Two regression tests in `WorkItemServiceTest.cs`:

- `..._PersistsItemOnceWithoutDuplicatingTransitions` — one row persisted, transitions not double-written
- `..._FollowUpSyncStillPersistsItemOnce` — the *second* sync stays clean, pinning the actual production crash

`AssignIdentitiesOnSave` is load-bearing: the fixture's `Save()` is a no-op, so both duplicate rows would keep `Id == 0`, and `SyncStateTransitions` (which dedupes on `WorkItemId`) would silently filter the second write — making the double-write invisible and the assertion falsely pass.

## ⚠️ Gates not run locally — CI is the first real compile

No .NET SDK is reachable from the environment this was authored in: `dot.net`, `builds.dotnet.microsoft.com`, `api.nuget.org` and the Ubuntu mirrors all return 403 under its egress policy, and there is no NuGet cache to restore from. So `dotnet build` and `dotnet test` were **not** executed.

RED was established instead by porting `RefreshWorkItems` + `SyncStateTransitions` over the fixture doubles and simulating both paths:

| | rows | transitions | second sync |
|---|---|---|---|
| current code | 2 | 2 | `InvalidOperationException` |
| with fix | 1 | 1 | clean |

Compensating checks done by hand, since CI must stay green:

- every helper signature the new tests call verified against its declaration (`CreateWorkItemWithTransitions`, `CreateIncomingFor`, `IWorkTrackingConnector.GetWorkItemsForTeam` → `Task<IEnumerable<WorkItem>>`, `IRepository.Save()` → `Task`)
- `Scripts/ledger_check.py` run against the working tree — clean
- `docs/ci-learnings.md` rules pre-applied: NUnit2046 (`Has.Count.EqualTo`), NUnit2056 (`Assert.EnterMultipleScope`), NUnit4002, CA1861, CA1859 (new helpers return concrete `List<T>`), CS9236, S107 (existing pragma untouched)

## Related

Same defect class as the **2026-05-25** `ci-learnings` entry, where duplicate demo-CSV `ReferenceId`s crashed `RefreshWorkItems` on re-sync and was fixed in the *data*. The guard now holds regardless of source — worth a `Recurrence: 1` note next time `/clean-ci` touches that entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_013ia8zwvCcyX97dUjWUHywc)_